### PR TITLE
fix: Properly Map Reindex's User-Provided Keys and Indexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,11 +200,15 @@ module.exports = function( given_collection ){
 
     if( !details.keys && details.key ) keys_to_index = [ details.key ];
     else if( !details.keys ) keys_to_index = api.keys();
-    if( Object.prototype.toString.call(keys_to_index) !== '[object Array]' ) throw new Error('unexpected datatype');
+    else keys_to_index = details.keys;
+
+    if( Object.prototype.toString.call(keys_to_index) !== '[object Array]' ) throw new Error('unexpected datatype for keys to index');
 
     if( !details.indexes && details.index ) indexes_to_run = [ details.index ];
     else if( !details.indexes ) indexes_to_run = api.indexes();
-    if( Object.prototype.toString.call(indexes_to_run) !== '[object Array]' ) throw new Error('unexpected datatype');
+    else indexes_to_run = details.indexes;
+
+    if( Object.prototype.toString.call(indexes_to_run) !== '[object Array]' ) throw new Error('unexpected datatype for indexes to run');
 
     indexes_to_run.forEach( function( index_name ){
       var index = indexes[ index_name ],


### PR DESCRIPTION
When trying to reindex multiple keys and/or multiple indexes, the array(s) passed to the api arguments were not linked to the internal data structure used.

If you tried `collection.reindex({ indexes: [ 'created:this-hour', 'created:today' ] })`, the collection will fail with an error "unexpected datatype" because user-specified indexes were unintentionally not getting passed to the actual reindex logic.

This PR makes sure that user-specified indexes and keys given to reindex are properly passed to reindex logic.

